### PR TITLE
Heuristic header

### DIFF
--- a/src/main/java/org/allenai/scienceparse/pdfapi/PDFDoc.java
+++ b/src/main/java/org/allenai/scienceparse/pdfapi/PDFDoc.java
@@ -10,4 +10,17 @@ import java.util.List;
 public class PDFDoc {
     public List<PDFPage> pages;
     public PDFMetadata meta;
+    /**
+     * Index in the lines of the first page which is the stop (one beyond the last)
+     * line that makes the header of the document (the title, authors, etc.)
+     *
+     * This is < 0 if we can't find an approriate header/main cut.
+     */
+    private final int headerStopLinePosition;
+
+    public List<PDFLine> heuristicHeader() {
+        return headerStopLinePosition >= 0 ?
+            pages.get(0).lines.subList(0, headerStopLinePosition) :
+            null;
+    }
 }

--- a/src/main/java/org/allenai/scienceparse/pdfapi/PDFLine.java
+++ b/src/main/java/org/allenai/scienceparse/pdfapi/PDFLine.java
@@ -47,4 +47,8 @@ public class PDFLine {
     public String lineText() {
         return tokens.stream().map(PDFToken::getToken).collect(Collectors.joining(" "));
     }
+
+    public double avgFontSize() {
+        return tokens.stream().mapToDouble(t -> t.getFontMetrics().getPtSize()).average().orElse(0.0);
+    }
 }

--- a/src/test/java/org/allenai/scienceparse/pdfapi/PDFExtractorTest.java
+++ b/src/test/java/org/allenai/scienceparse/pdfapi/PDFExtractorTest.java
@@ -12,8 +12,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class
-        PDFExtractorTest {
+public class PDFExtractorTest {
 
     @SneakyThrows
     private void testPDF(String id) {
@@ -119,6 +118,10 @@ public class
             numEvents ++;
             PDFExtractor.Options opts = PDFExtractor.Options.builder().useHeuristicTitle(false).build();
             PDFDoc doc = new PDFExtractor(opts).extractFromInputStream(new FileInputStream(pdfFile));
+            if (doc == null) {
+                fn++;
+                continue;
+            }
             String guessTitle = doc.getMeta().getTitle();
             if (guessTitle == null) {
                 // Didn't guess but there is an answer


### PR DESCRIPTION
Heuristic header extracton from first page. On the ACL set, nothing failed to extract a header from the last 15 years of papers (published 2000 or later). There are older papers where the conventions are significantly different.

PS: @rodneykinney, I think you should merge pdfbox-2.0 into master. 
