### PR TITLE
Remove log INFO and add column headers

### DIFF
--- a/src/it/java/org/allenai/scienceparse/MetaEvalSpec.scala
+++ b/src/it/java/org/allenai/scienceparse/MetaEvalSpec.scala
@@ -222,7 +222,7 @@ class MetaEvalSpec extends UnitSpec with Datastores with Logging {
     // calculate precision and recall for all metrics
     //
 
-    logger.info("Evaluation results:")
+    println(f"""${"EVALUATION RESULTS"}%-30s\t${"PRECISION"}%10s\t${"RECALL"}%10s""")
     val prResults = allGoldData.map { case (metric, docid, goldData) =>
       extractions(docid) match {
         case Failure(_) => (metric, (0.0, 0.0))
@@ -233,7 +233,7 @@ class MetaEvalSpec extends UnitSpec with Datastores with Logging {
       val (ps, rs) = prs.map(_._2).unzip
       (ps.sum / ps.size, rs.sum / rs.size)
     }.toArray.sortBy(_._1.name).foreach { case (metric, (p, r)) =>
-      logger.info(f"${metric.name}%-30s\t$p%.3f\t$r%.3f")
+      println(f"${metric.name}%-30s\t$p%10.3f\t$r%10.3f")
     }
   }
 }


### PR DESCRIPTION
Master:

```
INFO  o.allenai.scienceparse.MetaEvalSpec: Evaluation results:
INFO  o.allenai.scienceparse.MetaEvalSpec: abstract                         0.222   0.222
INFO  o.allenai.scienceparse.MetaEvalSpec: abstractNormalized               0.222   0.222
INFO  o.allenai.scienceparse.MetaEvalSpec: authorFullName                   0.718   0.695
INFO  o.allenai.scienceparse.MetaEvalSpec: authorFullNameNormalized         0.746   0.721
INFO  o.allenai.scienceparse.MetaEvalSpec: authorLastName                   0.809   0.783
INFO  o.allenai.scienceparse.MetaEvalSpec: authorLastNameNormalized         0.829   0.801
INFO  o.allenai.scienceparse.MetaEvalSpec: bibAll                           0.024   0.014
INFO  o.allenai.scienceparse.MetaEvalSpec: bibAllNormalized                 0.032   0.020
INFO  o.allenai.scienceparse.MetaEvalSpec: bibAuthors                       0.504   0.349
INFO  o.allenai.scienceparse.MetaEvalSpec: bibAuthorsNormalized             0.683   0.498
INFO  o.allenai.scienceparse.MetaEvalSpec: bibCounts                        1.000   0.659
INFO  o.allenai.scienceparse.MetaEvalSpec: bibTitles                        0.837   0.607
INFO  o.allenai.scienceparse.MetaEvalSpec: bibTitlesNormalized              0.840   0.609
INFO  o.allenai.scienceparse.MetaEvalSpec: bibVenues                        0.062   0.029
INFO  o.allenai.scienceparse.MetaEvalSpec: bibVenuesNormalized              0.062   0.029
INFO  o.allenai.scienceparse.MetaEvalSpec: bibYears                         0.909   0.658
INFO  o.allenai.scienceparse.MetaEvalSpec: title                            0.414   0.414
INFO  o.allenai.scienceparse.MetaEvalSpec: titleNormalized                  0.817   0.817
```

This:

```
EVALUATION RESULTS               PRECISION      RECALL
abstract                             0.222       0.222
abstractNormalized                   0.222       0.222
authorFullName                       0.718       0.695
authorFullNameNormalized             0.746       0.721
authorLastName                       0.809       0.783
authorLastNameNormalized             0.829       0.801
bibAll                               0.024       0.014
bibAllNormalized                     0.032       0.020
bibAuthors                           0.504       0.349
bibAuthorsNormalized                 0.683       0.498
bibTitles                            0.837       0.607
bibTitlesNormalized                  0.840       0.609
bibVenues                            0.062       0.029
bibVenuesNormalized                  0.062       0.029
bibYears                             0.909       0.658
title                                0.414       0.414
titleNormalized                      0.817       0.817
```

I figure the logging isn't very helpful here since this is the intended output of the class, and not just informational logs. Also this adds labels to what each column means.
