### PR TITLE
Use CRF for authors all the time

### DIFF
--- a/src/main/java/org/allenai/scienceparse/Parser.java
+++ b/src/main/java/org/allenai/scienceparse/Parser.java
@@ -923,18 +923,24 @@ public class Parser {
     seq = seq.subList(0, Math.min(seq.size(), headerMax));
     seq = PDFToCRFInput.padSequence(seq);
 
-    if (doc.meta == null || doc.meta.title == null) { //use the model
+    { // get title and authors from the CRF
       List<String> outSeq = model.bestGuess(seq);
       //the output tag sequence will not include the start/stop states!
       outSeq = PDFToCRFInput.padTagSequence(outSeq);
       em = new ExtractedMetadata(seq, outSeq);
       em.source = ExtractedMetadata.Source.CRF;
-    } else {
-      em = new ExtractedMetadata(doc.meta.title, doc.meta.authors, doc.meta.createDate);
-      em.source = ExtractedMetadata.Source.META;
     }
-    if (doc.meta.createDate != null)
-      em.setYearFromDate(doc.meta.createDate);
+
+    // use PDF metadata if it's there
+    if(doc.meta != null) {
+      if (doc.meta.title != null) {
+        em.setTitle(doc.meta.title);
+        em.source = ExtractedMetadata.Source.META;
+      }
+      if (doc.meta.createDate != null)
+        em.setYearFromDate(doc.meta.createDate);
+    }
+    
     clean(em);
     em.raw = PDFDocToPartitionedText.getRaw(doc);
     em.creator = doc.meta.creator;


### PR DESCRIPTION
Turns out that authors misidentify themselves in the PDF metadata. Switching to using the CRF all the time for authors, instead of only when there is no metadata, gives us a 2% boost on both precision and recall.

For titles, we still prefer the PDF metadata. The data shows that it's more likely to be correct, when present, than the output from the CRF.
