### PR TITLE
Fix page numbers

### DIFF
--- a/src/main/java/org/allenai/scienceparse/PDFToCRFInput.java
+++ b/src/main/java/org/allenai/scienceparse/PDFToCRFInput.java
@@ -241,9 +241,9 @@ public class PDFToCRFInput {
       List<PDFLine> header = pdf.heuristicHeader();
       addLineTokens(out, header, 0);
     } else {
-      int pg = 0;
-      for (PDFPage p : pdf.getPages()) {
-        addLineTokens(out, p.getLines(), pg);
+      List<PDFPage> pages = pdf.getPages();
+      for (int pageNum = 0; pageNum < pages.size(); pageNum++) {
+        addLineTokens(out, pages.get(pageNum).lines, pageNum);
       }
     }
     return out;


### PR DESCRIPTION
Fixes #65.

I was a little hesitant to patch this myself since I have not dug deep into science-parse, and if page numbers are used as features anywhere the classifier might have to be re-trained. But it appears that that is not the case.
