### PR TITLE
Add time constraints to feedback store. Make schema upgrade configurable.

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -9,8 +9,6 @@ org.allenai.scienceparse.Server {
   }
 
   db-as-root = {
-    upgradeSchema = true
-
     url = ${org.allenai.scienceparse.Server.db.url}
     user = "root"
     password = null

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -9,6 +9,8 @@ org.allenai.scienceparse.Server {
   }
 
   db-as-root = {
+    upgradeSchema = true
+
     url = ${org.allenai.scienceparse.Server.db.url}
     user = "root"
     password = null

--- a/server/src/main/scala/org/allenai/scienceparse/FeedbackStore.scala
+++ b/server/src/main/scala/org/allenai/scienceparse/FeedbackStore.scala
@@ -1,7 +1,7 @@
 package org.allenai.scienceparse
 
-import com.typesafe.config.{Config, ConfigFactory}
-import org.allenai.common.{Logging, Resource}
+import com.typesafe.config.{ConfigFactory, Config}
+import org.allenai.common.{Resource, Logging}
 import org.allenai.common.Config._
 
 import scalikejdbc._

--- a/server/src/main/scala/org/allenai/scienceparse/FeedbackStore.scala
+++ b/server/src/main/scala/org/allenai/scienceparse/FeedbackStore.scala
@@ -30,12 +30,12 @@ object FeedbackStore extends Logging {
     ConnectionPool.singleton(dbUrl, dbUser, dbPassword)
 
     // upgrade the schema if necessary
-    val dbRootConfig: Config = config[Config]("org.allenai.scienceparse.Server.db-as-root")
-    if (dbRootConfig[Boolean]("upgradeSchema")){
-      val dbUrl = dbRootConfig.getString("url")
+    {
+      val dbConfig: Config = config[Config]("org.allenai.scienceparse.Server.db-as-root")
+      val dbUrl = dbConfig.getString("url")
       logger.info(s"Connecting to $dbUrl")
-      val dbUser = dbRootConfig.getString("user")
-      val dbPassword = dbRootConfig.get[String]("password").getOrElse(
+      val dbUser = dbConfig.getString("user")
+      val dbPassword = dbConfig.get[String]("password").getOrElse(
         throw new IllegalArgumentException("Root password for DB not set. Please set org.allenai.scienceparse.Server.db-as-root.password."))
 
       val rootConnectionPoolName = "rootConnectionPool"

--- a/server/src/main/scala/org/allenai/scienceparse/SPServer.scala
+++ b/server/src/main/scala/org/allenai/scienceparse/SPServer.scala
@@ -386,7 +386,7 @@ class SPServer(
   }.getOrElse(throw feedbackUnavailableException)
 
   private def correctionsGetAll(request: SPRequest) = feedbackStore.map { store =>
-    val result = store.getAllFeedback
+    val result = store.getAllFeedback()
     // This keeps the whole result set in memory, which is bad. It should be streamed.
     // ScalikeJDBC already insists on keeping it in memory, so I didn't take the time to optimize
     // it here.

--- a/server/src/main/scala/org/allenai/scienceparse/SPServer.scala
+++ b/server/src/main/scala/org/allenai/scienceparse/SPServer.scala
@@ -1,17 +1,17 @@
 package org.allenai.scienceparse
 
-import java.io.{ ByteArrayInputStream, File, InputStream }
-import java.security.{ DigestInputStream, MessageDigest }
-import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
-
-import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
+import java.io.{ByteArrayInputStream, File, InputStream}
+import java.security.{DigestInputStream, MessageDigest}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
-import com.fasterxml.jackson.databind.{ JsonMappingException, ObjectMapper }
+import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import org.allenai.common.{ Logging, Resource }
+import org.allenai.common.{Logging, Resource}
+
 import org.apache.commons.io.IOUtils
-import org.eclipse.jetty.server.{ Request, Server }
+import org.eclipse.jetty.server.{Request, Server}
 import org.eclipse.jetty.server.handler.AbstractHandler
 import scopt.OptionParser
 
@@ -20,6 +20,8 @@ import scala.util.matching.Regex
 import scala.collection.JavaConverters._
 import spray.json._
 import LabeledDataJsonProtocol._
+
+import java.time.Instant
 
 object SPServer extends Logging {
   def main(args: Array[String]): Unit = {
@@ -386,7 +388,11 @@ class SPServer(
   }.getOrElse(throw feedbackUnavailableException)
 
   private def correctionsGetAll(request: SPRequest) = feedbackStore.map { store =>
-    val result = store.getAllFeedback()
+
+    val onOrAfterOpt = request.queryParams.get("onOrAfter").map(s => Instant.ofEpochMilli(s.toLong))
+    val beforeOpt = request.queryParams.get("before").map(s => Instant.ofEpochMilli(s.toLong))
+
+    val result = store.getAllFeedback(onOrAfterOpt, beforeOpt)
     // This keeps the whole result set in memory, which is bad. It should be streamed.
     // ScalikeJDBC already insists on keeping it in memory, so I didn't take the time to optimize
     // it here.


### PR DESCRIPTION
I mean to depend on the server module directly. 

Also I don't want to configure the db root user elsewhere, and want to instead disable the schema ugprade logic, i.e. 
  `-Dorg.allenai.scienceparse.Server.db-as-root.upgradeSchema=false`

Testing:
  - Ran a custom main to check the presence or absence of timeadded constraints
  - Built and ran `sbt server/assembly` to confirm API endpoint still works.