### PR TITLE
Make master tests green again ...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/science-parse
+    docker:
+      - image: openjdk:8
+    environment:
+      SBT_VERSION: 1.2.8
+    steps:
+      - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
+      - run:
+          name: Get sbt binary
+          command: |
+            apt update && apt install -y curl
+            curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
+            dpkg -i sbt-$SBT_VERSION.deb
+            rm sbt-$SBT_VERSION.deb
+            apt-get update && apt-get clean && apt-get autoclean
+      - checkout
+      - restore_cache:
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: sbt-cache
+      - run:
+          name: Clean package
+          command: cat /dev/null | sbt clean
+      - run:
+          name: Test package
+          command: cat /dev/null | sbt test
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: target/universal/science-parse.zip
+          destination: science-parse
+      - save_cache:
+          key: sbt-cache
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.m2"

--- a/core/src/main/java/org/allenai/scienceparse/PaperSource.java
+++ b/core/src/main/java/org/allenai/scienceparse/PaperSource.java
@@ -1,5 +1,7 @@
 package org.allenai.scienceparse;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -9,7 +11,9 @@ import java.io.InputStream;
 public abstract class PaperSource {
     abstract InputStream getPdf(String paperId) throws IOException;
 
-    private static PaperSource defaultPaperSource = null;
+    @VisibleForTesting
+    public static PaperSource defaultPaperSource = null;
+
     static synchronized PaperSource getDefault() {
         if(defaultPaperSource == null)
             defaultPaperSource = new RetryPaperSource(S2PaperSource$.MODULE$, 5);

--- a/core/src/test/java/org/allenai/scienceparse/ParserTest.java
+++ b/core/src/test/java/org/allenai/scienceparse/ParserTest.java
@@ -93,10 +93,10 @@ public class ParserTest {
 
     Parser.ParseOpts opts = new Parser.ParseOpts();
     opts.iterations = 10;
-    opts.threads = 1;
+    opts.threads = 4;
     opts.modelFile = testModelFile.getPath();
     opts.headerMax = Parser.MAXHEADERWORDS;
-    opts.backgroundSamples = 2;
+    opts.backgroundSamples = 3;
     opts.gazetteerFile = null;
     opts.trainFraction = 0.9;
     opts.backgroundDirectory = resourceDirectory("/groundTruth.json");


### PR DESCRIPTION
Reads test PDFs from the local file system instead of from AI2 S3 bucket / site which no longer hosts these PDFs (taken down?) or redirects to a new location (new ID). 

Hacked to the extreme, but I don't want to spend any more time getting this to green.