### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ features, but higher quality in the output. Check out the details at https://git
 
 There are three different ways to get started with SP. Each has its own document:
 
- * [Server](server/README.md): This contains the SP server. It's useful for PDF parsing as a service. It's also probably the easiest way to get going.
  * [CLI](cli/README.md): This contains the command line interface to SP. That's most useful for batch processing.
+ * [Server](server/README.md): This contains the SP server. It's useful for PDF parsing as a service.
  * [Core](core/README.md): This contains SP as a library. It has all the extraction code, plus training and evaluation. Both server and CLI use this to do the actual work.
 
 ## How to include into your own project

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,20 +1,23 @@
 # Science Parse Command Line Interface
 
-Science Parse has a command line interface called "RunSP". To build it into a super-jar, run `sbt cli/assembly`. This will download all dependencies and make a bundled jar that contains SP itself, plus all of its dependencies.
+Download the latest science-parse-cli-assembly executable from the [Releases](https://github.com/allenai/science-parse/releases) page
 
 You can run it like this:
 ```
 java -jar jarfile.jar --help
 ```
-That will print all the command line options you can use with it. I won't describe all of them here, but there are a few important described below.
 
-## Memory
+That will print all the command line options you can use with it. I won't describe all of them here, but there are a few important described below.
 
 Science Parse needs quite a lot of memory. We recommend you run it with at least 6GB of heap, like this:
 ```
 java -Xmx6g -jar jarfile.jar 18bc3569da037a6cb81fb081e2856b77b321c139
 ```
 Note that some documents need more memory to parse than others.
+
+## Building from source
+
+Science Parse has a command line interface called "RunSP". To build it into a super-jar, run `sbt cli/assembly`. This will download all dependencies and make a bundled jar that contains SP itself, plus all of its dependencies.
 
 ## Specifying input
 


### PR DESCRIPTION
You can see from the Issues page and Google that I am not the only one that thought you had to compile the project in order to eventually get it to run, which is a major headache. I think the proposed change makes it much more clear that you only need to download the executable.